### PR TITLE
Day15 pickup

### DIFF
--- a/wp-content/themes/tf30/index.php
+++ b/wp-content/themes/tf30/index.php
@@ -1,7 +1,12 @@
 
 <?php get_header(); ?>
 
-<?php get_template_part('template-parts/pickup'); ?>
+<?php 
+// get_template_part('template-parts/pickup'); 
+?>
+
+<?php get_template_part('template-parts/pickup_by_tag'); ?>
+
 
 	<!-- content -->
 	<div id="content">

--- a/wp-content/themes/tf30/index.php
+++ b/wp-content/themes/tf30/index.php
@@ -1,49 +1,7 @@
 
-<?php
-  get_header();
-?>
+<?php get_header(); ?>
 
-	<!-- pickup -->
-	<div id="pickup">
-		<div class="inner">
-
-			<div class="pickup-items">
-
-				<a href="#" class="pickup-item">
-					<div class="pickup-item-img">
-						<img src="<?php echo get_template_directory_uri() ?>/img/pickup1.png" alt="">
-						<div class="pickup-item-tag">カテゴリ名</div><!-- /pickup-item-tag -->
-					</div><!-- /pickup-item-img -->
-					<div class="pickup-item-body">
-						<h2 class="pickup-item-title">記事のタイトルが入ります記事のタイトルが入ります記事のタイトルが入ります</h2><!-- /pickup-item-title -->
-					</div><!-- /pickup-item-body -->
-				</a><!-- /pickup-item -->
-
-				<a href="#" class="pickup-item">
-					<div class="pickup-item-img">
-						<img src="<?php echo get_template_directory_uri() ?>/img/pickup2.png" alt="">
-						<div class="pickup-item-tag">カテゴリ名</div><!-- /pickup-item-tag -->
-					</div><!-- /pickup-item-img -->
-					<div class="pickup-item-body">
-						<h2 class="pickup-item-title">記事のタイトルが入ります記事のタイトルが入ります記事のタイトルが入ります</h2><!-- /pickup-item-title -->
-					</div><!-- /pickup-item-body -->
-				</a><!-- /pickup-item -->
-
-				<a href="#" class="pickup-item">
-					<div class="pickup-item-img">
-						<img src="<?php echo get_template_directory_uri() ?>/img/pickup3.png" alt="">
-						<div class="pickup-item-tag">カテゴリ名</div><!-- /pickup-item-tag -->
-					</div><!-- /pickup-item-img -->
-					<div class="pickup-item-body">
-						<h2 class="pickup-item-title">記事のタイトルが入ります記事のタイトルが入ります記事のタイトルが入ります</h2><!-- /pickup-item-title -->
-					</div><!-- /pickup-item-body -->
-				</a><!-- /pickup-item -->
-
-			</div><!-- /pickup-items -->
-
-		</div><!-- /inner -->
-	</div><!-- /pickup -->
-
+<?php get_template_part('template-parts/pickup'); ?>
 
 	<!-- content -->
 	<div id="content">

--- a/wp-content/themes/tf30/template-parts/pickup.php
+++ b/wp-content/themes/tf30/template-parts/pickup.php
@@ -1,0 +1,27 @@
+	<!-- pickup -->
+	<div id="pickup">
+		<div class="inner">
+
+			<div class="pickup-items">
+        <?php $pickup_ids = array(23, 8, 1); //ピックアップする記事の投稿IDを指定 ?>
+        <?php foreach($pickup_ids as $id) : ?>
+				<a href="<?php echo esc_url(get_permalink($id)); ?>" class="pickup-item">
+					<div class="pickup-item-img">
+            <?php if (has_post_thumbnail($id)) {
+              echo get_the_post_thumbnail($id, 'large');
+            } else {
+              echo '<img src="' . esc_url(get_template_directory_uri()) .  '/img/noimg.png" alt="">';
+            } ?>
+            <div class="pickup-item-tag"><?php my_the_post_category(false, $id); ?></div><!-- /pickup-item-tag -->
+					</div><!-- /pickup-item-img -->
+					<div class="pickup-item-body">
+						<h2 class="pickup-item-title"><?php echo esc_html(get_the_title ($id)); ?></h2><!-- /pickup-item-title -->
+					</div><!-- /pickup-item-body -->
+				</a><!-- /pickup-item -->
+        <?php endforeach; ?>
+
+
+			</div><!-- /pickup-items -->
+
+		</div><!-- /inner -->
+	</div><!-- /pickup -->

--- a/wp-content/themes/tf30/template-parts/pickup_by_tag.php
+++ b/wp-content/themes/tf30/template-parts/pickup_by_tag.php
@@ -1,0 +1,32 @@
+	<!-- pickup -->
+	<div id="pickup">
+		<div class="inner">
+
+			<div class="pickup-items">
+        <?php $pickup_posts = get_posts(array(
+          'post_type' => 'post',  //投稿タイプ
+          'posts_per_page' => '3',  //3件取得
+          'tag' => 'pickup',  //pickupタグがついたものを
+          'orderby' => 'DESC',  //新しい順に
+        )); ?>
+        
+        <?php foreach ($pickup_posts as $post) : setup_postdata($post); ?>
+				<a href="<?php echo esc_url(get_permalink()); ?>" class="pickup-item">
+					<div class="pickup-item-img">
+            <?php if (has_post_thumbnail()) {
+              the_post_thumbnail('large');
+            } else {
+              echo '<img src="' . esc_url(get_template_directory_uri()) .  '/img/noimg.png" alt="">';
+            } ?>
+            <div class="pickup-item-tag"><?php my_the_post_category(false); ?></div><!-- /pickup-item-tag -->
+					</div><!-- /pickup-item-img -->
+					<div class="pickup-item-body">
+						<h2 class="pickup-item-title"><?php echo the_title (); ?></h2><!-- /pickup-item-title -->
+					</div><!-- /pickup-item-body -->
+				</a><!-- /pickup-item -->
+        <?php endforeach; wp_reset_postdata(); ?>
+
+			</div><!-- /pickup-items -->
+
+		</div><!-- /inner -->
+	</div><!-- /pickup -->


### PR DESCRIPTION
# why
ピックアップ記事の要望があったため

# what
ピックアップ記事の実装方法2つを用意
1：投稿IDで指定する方法（固定ページ向き）
2：タグpickupを利用する方法（クライアントが自分で表示を切り替えたい場合）
